### PR TITLE
Add baseAmounts

### DIFF
--- a/contracts/interfaces/IStrategyV2.sol
+++ b/contracts/interfaces/IStrategyV2.sol
@@ -24,7 +24,9 @@ interface IStrategyV2 {
 
   function withdrawToSplitter(uint amount) external;
 
-  function investAll() external;
+  /// @notice Stakes everything the strategy holds into the reward pool.
+  /// @param amount_ Amount transferred to the strategy balance just before calling this function
+  function investAll(uint amount_) external;
 
   function doHardWork() external returns (uint earned, uint lost);
 

--- a/contracts/strategy/StrategyBaseV2.sol
+++ b/contracts/strategy/StrategyBaseV2.sol
@@ -66,7 +66,6 @@ abstract contract StrategyBaseV2 is IStrategyV2, ControllableV3 {
   event WithdrawAllFromPool(uint amount);
   event Claimed(address token, uint amount);
   event CompoundRatioChanged(uint oldValue, uint newValue);
-  event SentToForwarder(address forwarder, address token, uint amount);
   /// @notice {baseAmounts} of {asset} is changed on the {amount} value
   event UpdateBaseAmounts(address asset, int amount);
 
@@ -280,14 +279,6 @@ abstract contract StrategyBaseV2 is IStrategyV2, ControllableV3 {
 
       require(difference * FEE_DENOMINATOR / investedAssetsUSD <= priceChangeTolerance, IMPACT_TOO_HIGH);
     }
-  }
-
-  /// @dev Must use this function for any transfers to Forwarder.
-  function _sendToForwarder(address token, uint amount) internal {
-    address forwarder = IController(controller()).forwarder();
-    IERC20(token).safeTransfer(forwarder, amount);
-    IForwarder(forwarder).distribute(token);
-    emit SentToForwarder(forwarder, token, amount);
   }
 
   // *************************************************************

--- a/contracts/strategy/StrategyBaseV2.sol
+++ b/contracts/strategy/StrategyBaseV2.sol
@@ -223,7 +223,7 @@ abstract contract StrategyBaseV2 is IStrategyV2, ControllableV3 {
     address _splitter
   ) internal view returns (uint balance) {
     balance = IERC20(_asset).balanceOf(address(this));
-    if (assetPrice != 0 || investedAssetsUSD != 0) {
+    if (assetPrice != 0 && investedAssetsUSD != 0) {
 
       uint withdrew = balance > balanceBefore ? balance - balanceBefore : 0;
       uint withdrewUSD = withdrew * assetPrice / 1e18;

--- a/contracts/test/MockStrategy.sol
+++ b/contracts/test/MockStrategy.sol
@@ -130,6 +130,10 @@ contract MockStrategy is StrategyBaseV2 {
     compoundRatio = ratio;
   }
 
+  function setBaseAmount(address asset_, uint amount_) external {
+    baseAmounts[asset_] = amount_;
+  }
+
   ////////////////////////////////////////////////////////
   ///           Access to internal functions
   ////////////////////////////////////////////////////////

--- a/contracts/test/MockStrategy.sol
+++ b/contracts/test/MockStrategy.sol
@@ -44,7 +44,12 @@ contract MockStrategy is StrategyBaseV2 {
       address forwarder = IController(controller()).forwarder();
       if (forwarder != address(0)) {
         MockToken(asset).mint(address(this), lastEarned - toCompound);
-        _sendToForwarder(asset, lastEarned - toCompound);
+
+        address[] memory tokens = new address[](1);
+        tokens[0] = asset;
+        uint[] memory amounts = new uint[](1);
+        amounts[0] = lastEarned - toCompound;
+        IForwarder(forwarder).registerIncome(tokens, amounts, ISplitter(splitter).vault(), true);
       }
     }
     IERC20(asset).transfer(address(pool), IERC20(asset).balanceOf(address(this)));

--- a/contracts/test/MockStrategySimple.sol
+++ b/contracts/test/MockStrategySimple.sol
@@ -48,7 +48,8 @@ contract MockStrategySimple is ControllableV3, IStrategyV2 {
     IERC20(asset).transfer(splitter, amount - _slippage);
   }
 
-  function investAll() external override {
+  function investAll(uint amount_) external override {
+    amount_; // hide warning
     // noop
   }
 

--- a/contracts/vault/StrategySplitterV2.sol
+++ b/contracts/vault/StrategySplitterV2.sol
@@ -24,7 +24,7 @@ contract StrategySplitterV2 is ControllableV3, ReentrancyGuard, ISplitter {
   // *********************************************
 
   /// @dev Version of this contract. Adjust manually on each code modification.
-  string public constant SPLITTER_VERSION = "2.0.0";
+  string public constant SPLITTER_VERSION = "2.0.1";
   /// @dev APR denominator. Represent 100% APR.
   uint public constant APR_DENOMINATOR = 100_000;
   /// @dev Delay between hardwork calls for a strategy.
@@ -652,7 +652,7 @@ contract StrategySplitterV2 is ControllableV3, ReentrancyGuard, ISplitter {
     }
   }
 
-  function _investToTopStrategy() internal returns (address){
+  function _investToTopStrategy() internal returns (address) {
     address strategy;
     address _asset = asset;
     uint balance = IERC20(_asset).balanceOf(address(this));
@@ -674,7 +674,7 @@ contract StrategySplitterV2 is ControllableV3, ReentrancyGuard, ISplitter {
       }
 
       IERC20(_asset).safeTransfer(strategy, toInvest);
-      IStrategyV2(strategy).investAll();
+      IStrategyV2(strategy).investAll(toInvest);
       balance -= toInvest;
       emit Invested(strategy, toInvest);
     }

--- a/test/vault/SplitterTests.ts
+++ b/test/vault/SplitterTests.ts
@@ -642,9 +642,19 @@ describe("Splitter and base strategy tests", function () {
       await strategy.connect(await Misc.impersonate(splitter.address)).investAll(0);
     });
 
-    it("withdraw to splitter when enough balance test", async () => {
-      await usdc.transfer(strategy.address, parseUnits('1', 6));
-      await strategy.connect(await Misc.impersonate(splitter.address)).withdrawToSplitter(parseUnits('1', 6));
+    describe("withdraw to splitter when enough balance test", () => {
+      it("withdraw to splitter when the amount on balance is registered in baseAmounts", async () => {
+        await usdc.transfer(strategy.address, parseUnits('1', 6));
+        await strategy.setBaseAmount(await strategy.asset(), parseUnits('1', 6));
+        await strategy.connect(await Misc.impersonate(splitter.address)).withdrawToSplitter(parseUnits('1', 6));
+      });
+      it("revert when the amount on balance is partly not registered in baseAmounts", async () => {
+        await usdc.transfer(strategy.address, parseUnits('1', 6));
+        await strategy.setBaseAmount(await strategy.asset(), parseUnits('0.5', 6));
+        await expect(
+          strategy.connect(await Misc.impersonate(splitter.address)).withdrawToSplitter(parseUnits('1', 6))
+        ).revertedWith("SB: Wrong amount"); // WRONG_AMOUNT
+      });
     });
 
     it("set compound ratio test", async () => {

--- a/test/vault/SplitterTests.ts
+++ b/test/vault/SplitterTests.ts
@@ -627,7 +627,7 @@ describe("Splitter and base strategy tests", function () {
     });
 
     it("strategy invest from 3rd party revert", async () => {
-      await expect(strategy.investAll()).revertedWith("SB: Denied");
+      await expect(strategy.investAll(0)).revertedWith("SB: Denied");
     });
 
     it("claim from 3d party revert", async () => {
@@ -639,7 +639,7 @@ describe("Splitter and base strategy tests", function () {
     });
 
     it("invest all with zero balance test", async () => {
-      await strategy.connect(await Misc.impersonate(splitter.address)).investAll();
+      await strategy.connect(await Misc.impersonate(splitter.address)).investAll(0);
     });
 
     it("withdraw to splitter when enough balance test", async () => {

--- a/test/vault/StrategyBaseV2Tests.ts
+++ b/test/vault/StrategyBaseV2Tests.ts
@@ -1,0 +1,245 @@
+import {SignerWithAddress} from "@nomiclabs/hardhat-ethers/signers";
+import {
+  ControllerMinimal,
+  MockGauge,
+  MockGauge__factory,
+  MockStrategy, MockStrategy__factory,
+  MockToken,
+  StrategySplitterV2,
+  TetuVaultV2
+} from "../../typechain";
+import {ethers} from "hardhat";
+import {TimeUtils} from "../TimeUtils";
+import {DeployerUtils} from "../../scripts/utils/DeployerUtils";
+import {formatUnits, parseUnits} from "ethers/lib/utils";
+import {Misc} from "../../scripts/utils/Misc";
+import {expect} from "chai";
+
+describe("StrategyBaseV2Tests", function () {
+  let snapshotBefore: string;
+  let snapshot: string;
+  let signer: SignerWithAddress;
+  let signer1: SignerWithAddress;
+  let signer2: SignerWithAddress;
+  let controller: ControllerMinimal;
+  let usdc: MockToken;
+  let tetu: MockToken;
+  let vault: TetuVaultV2;
+  let splitter: StrategySplitterV2;
+  let mockGauge: MockGauge;
+  let strategyAsSplitter: MockStrategy;
+
+//region begin, after
+  before(async function () {
+    [signer, signer1, signer2] = await ethers.getSigners()
+    snapshotBefore = await TimeUtils.snapshot();
+
+    controller = await DeployerUtils.deployMockController(signer);
+    usdc = await DeployerUtils.deployMockToken(signer, 'USDC', 6);
+    tetu = await DeployerUtils.deployMockToken(signer, 'TETU');
+    await usdc.transfer(signer2.address, parseUnits('1', 6));
+
+    mockGauge = MockGauge__factory.connect(await DeployerUtils.deployProxy(signer, 'MockGauge'), signer);
+    await mockGauge.init(controller.address)
+    vault = await DeployerUtils.deployTetuVaultV2(
+      signer,
+      controller.address,
+      usdc.address,
+      'USDC',
+      'USDC',
+      mockGauge.address,
+      0
+    );
+
+    splitter = await DeployerUtils.deploySplitter(signer, controller.address, usdc.address, vault.address);
+    await vault.setSplitter(splitter.address)
+
+    await usdc.connect(signer2).approve(vault.address, Misc.MAX_UINT);
+    await usdc.connect(signer1).approve(vault.address, Misc.MAX_UINT);
+    await usdc.approve(vault.address, Misc.MAX_UINT);
+
+    strategyAsSplitter = MockStrategy__factory.connect(
+      (await DeployerUtils.deployProxy(signer, 'MockStrategy')),
+      await Misc.impersonate(splitter.address)
+    );
+
+    const forwarder = await DeployerUtils.deployContract(signer, 'MockForwarder')
+    await controller.setForwarder(forwarder.address);
+
+    // initialize strategy
+    await strategyAsSplitter.init(controller.address, splitter.address);
+    await splitter.addStrategies([strategyAsSplitter.address], [100]);
+  });
+
+  after(async function () {
+    await TimeUtils.rollback(snapshotBefore);
+  });
+
+  beforeEach(async function () {
+    snapshot = await TimeUtils.snapshot();
+  });
+
+  afterEach(async function () {
+    await TimeUtils.rollback(snapshot);
+  });
+//endregion begin, after
+
+//region Unit tests
+  /**
+   * Tests for modification of StrategyBaseV2.baseAmounts after investing/withdrawing any amount from/to the splitter
+   */
+  describe("baseAmounts modifications", () => {
+    describe("investAll", () => {
+      describe("Good paths", () => {
+        it("should register invested amount", async () => {
+          const amount = parseUnits('1', 6);
+          await usdc.transfer(strategyAsSplitter.address, amount);
+          await strategyAsSplitter.investAll(amount);
+
+          const ret = await strategyAsSplitter.baseAmounts(usdc.address);
+          expect(ret).eq(amount);
+        });
+        it("should emit UpdateBaseAmounts", async () => {
+          const amount = parseUnits('1', 6);
+          await usdc.transfer(strategyAsSplitter.address, amount);
+
+          // todo Replace by await expect( after migration to hardhat-chai-matchers
+          expect(await strategyAsSplitter.investAll(amount))
+            .to.emit(strategyAsSplitter.address, "UpdateBaseAmounts")
+            .withArgs(usdc.address, amount);
+        });
+      });
+      describe("Bad paths", () => {
+        it("should revert with WRONG_AMOUNT", async () => {
+          const amount = parseUnits('1', 6);
+          // (!) The amount is NOT transferred // await usdc.transfer(splitter.address, amount);
+          await expect(strategyAsSplitter.investAll(amount))
+            .revertedWith("SB: Wrong amount");
+        });
+      });
+    });
+    describe("withdrawAllToSplitter", () => {
+      it("should unregister invested amount, no rewards", async () => {
+        const amount = parseUnits('1', 6);
+        await usdc.transfer(strategyAsSplitter.address, amount);
+        await strategyAsSplitter.investAll(amount);
+        const before = await strategyAsSplitter.baseAmounts(usdc.address);
+        await strategyAsSplitter.connect(await Misc.impersonate(splitter.address)).withdrawAllToSplitter();
+        const after = await strategyAsSplitter.baseAmounts(usdc.address);
+
+        const ret = [
+          +formatUnits(before, 6),
+          +formatUnits(after, 6)
+        ].join();
+        const expected = [
+          +formatUnits(amount, 6),
+          +formatUnits(0, 6)
+        ].join();
+        expect(ret).eq(expected);
+      });
+      it("should unregister invested amount, rewards", async () => {
+        const amount = parseUnits('1', 6);
+        const rewardsAmount = parseUnits('5', 6);
+        await usdc.transfer(strategyAsSplitter.address, amount);
+        await strategyAsSplitter.investAll(amount);
+
+        // add "rewards" to the strategy
+        // now, the total amount on strategy balance is more then the base amount
+        await usdc.transfer(strategyAsSplitter.address, rewardsAmount);
+        const before = await strategyAsSplitter.baseAmounts(usdc.address);
+        await strategyAsSplitter.withdrawAllToSplitter();
+        const after = await strategyAsSplitter.baseAmounts(usdc.address);
+
+        const ret = [
+          +formatUnits(before, 6),
+          +formatUnits(after, 6)
+        ].join();
+        const expected = [
+          +formatUnits(amount, 6),
+          +formatUnits(0, 6)
+        ].join();
+        expect(ret).eq(expected);
+      });
+      it("should emit UpdateBaseAmounts, rewards", async () => {
+        const amount = parseUnits('1', 6);
+        const rewardsAmount = parseUnits('5', 6);
+        await usdc.transfer(strategyAsSplitter.address, amount);
+        await strategyAsSplitter.investAll(amount);
+
+        // add "rewards" to the strategy
+        // now, the total amount on strategy balance is more than the base amount
+        await usdc.transfer(strategyAsSplitter.address, rewardsAmount);
+
+        // todo Replace by await expect( after migration to hardhat-chai-matchers
+        expect(await strategyAsSplitter.withdrawAllToSplitter())
+          .to.emit(strategyAsSplitter.address, "UpdateBaseAmounts")
+          .withArgs(usdc.address, amount.mul(-1));
+      });
+    });
+    describe("withdrawToSplitter", () => {
+      it("should unregister invested amount, no rewards", async () => {
+        const amount = parseUnits('1', 6);
+        const amountToWithdraw = parseUnits('0.3', 6);
+
+        await usdc.transfer(strategyAsSplitter.address, amount);
+        await strategyAsSplitter.investAll(amount);
+        const before = await strategyAsSplitter.baseAmounts(usdc.address);
+        await strategyAsSplitter.connect(await Misc.impersonate(splitter.address)).withdrawToSplitter(amountToWithdraw);
+        const after = await strategyAsSplitter.baseAmounts(usdc.address);
+
+        const ret = [
+          +formatUnits(before, 6),
+          +formatUnits(after, 6)
+        ].join();
+        const expected = [
+          +formatUnits(amount, 6),
+          +formatUnits(amount.sub(amountToWithdraw), 6)
+        ].join();
+        expect(ret).eq(expected);
+      });
+      it("should unregister invested amount, withdrawn amount > base amount", async () => {
+        const amount = parseUnits('1', 6);
+        const amountToWithdraw = parseUnits('5.5', 6);
+        const rewardsAmount = parseUnits('5', 6);
+        await usdc.transfer(strategyAsSplitter.address, amount);
+        await strategyAsSplitter.investAll(amount);
+
+        // add "rewards" to the strategy
+        // now, the total amount on strategy balance is more than the base amount
+        await usdc.transfer(strategyAsSplitter.address, rewardsAmount);
+        const before = await strategyAsSplitter.baseAmounts(usdc.address);
+        await strategyAsSplitter.withdrawToSplitter(amountToWithdraw);
+        const after = await strategyAsSplitter.baseAmounts(usdc.address);
+
+        const ret = [
+          +formatUnits(before, 6),
+          +formatUnits(after, 6)
+        ].join();
+        const expected = [
+          +formatUnits(amount, 6),
+          +formatUnits(0, 6)
+        ].join();
+        expect(ret).eq(expected);
+      });
+      it("should emit UpdateBaseAmounts, withdrawn amount > base amount", async () => {
+        const amount = parseUnits('1', 6);
+        const amountToWithdraw = parseUnits('5.5', 6);
+        const rewardsAmount = parseUnits('5', 6);
+
+        await usdc.transfer(strategyAsSplitter.address, amount);
+        await strategyAsSplitter.investAll(amount);
+
+        // add "rewards" to the strategy
+        // now, the total amount on strategy balance is more than the base amount
+        await usdc.transfer(strategyAsSplitter.address, rewardsAmount);
+
+        // todo Replace by await expect( after migration to hardhat-chai-matchers
+        expect(await strategyAsSplitter.withdrawToSplitter(amountToWithdraw))
+          .to.emit(strategyAsSplitter.address, "UpdateBaseAmounts")
+          .withArgs(usdc.address, amountToWithdraw.mul(-1));
+      });
+    });
+  });
+
+//endregion Unit tests
+});


### PR DESCRIPTION
Add baseAmounts to StrategyBaseV2, add _decreaseBaseAmount/_increaseBaseAmount
Add param {amount_} to IStrategyV2.investAll. The function name wasn't changed because it still invests all balance.
Add tests for baseAmounts increment/decrement during deposit/withdraw, see StrategyBaseV2Tests
Fix possible divizion by zer error (see investedAssetsUSD)
Remove deprecated _sendToForwarder and related event