### PR TITLE
StrategyBaseV2: add performanceFee and performanceReceiver

### DIFF
--- a/contracts/interfaces/IStrategyV2.sol
+++ b/contracts/interfaces/IStrategyV2.sol
@@ -48,4 +48,11 @@ interface IStrategyV2 {
   /// @notice Max amount that can be deposited to the strategy (its internal capacity), see SCB-593.
   ///         0 means no deposit is allowed at this moment
   function capacity() external view returns (uint);
+
+  /// @notice {performanceFee}% of total profit is sent to the {performanceReceiver} before compounding
+  function performanceReceiver() external view returns (address);
+
+  /// @notice A percent of total profit that is sent to the {performanceReceiver} before compounding
+  /// @dev use FEE_DENOMINATOR
+  function performanceFee() external view returns (uint);
 }

--- a/contracts/test/MockStrategySimple.sol
+++ b/contracts/test/MockStrategySimple.sol
@@ -22,6 +22,8 @@ contract MockStrategySimple is ControllableV3, IStrategyV2 {
   uint internal lastLost;
 
   uint internal _capacity;
+  address public override performanceReceiver;
+  uint public override performanceFee;
 
   function init(
     address controller_,
@@ -33,6 +35,8 @@ contract MockStrategySimple is ControllableV3, IStrategyV2 {
     asset = _asset;
     isReadyToHardWork = true;
     _capacity = type(uint).max; // unlimited capacity by default
+    performanceReceiver = IController(controller_).governance();
+    performanceFee = 10_000;
   }
 
   function totalAssets() public view override returns (uint) {
@@ -55,7 +59,7 @@ contract MockStrategySimple is ControllableV3, IStrategyV2 {
   function investAll(
     uint amount_,
     bool updateTotalAssetsBeforeInvest_
-  ) external override returns (
+  ) external pure override returns (
     int totalAssetsDelta
   ) {
     amount_; // hide warning
@@ -90,4 +94,9 @@ contract MockStrategySimple is ControllableV3, IStrategyV2 {
     _capacity = capacity_;
   }
 
+  /// @notice Set performance fee and receiver
+  function setupPerformanceFee(uint fee_, address receiver_) external {
+    performanceFee = fee_;
+    performanceReceiver = receiver_;
+  }
 }

--- a/test/vault/SplitterTests.ts
+++ b/test/vault/SplitterTests.ts
@@ -747,7 +747,7 @@ describe("Splitter and base strategy tests", function () {
         await strategy.setBaseAmount(await strategy.asset(), parseUnits('0.5', 6));
         await expect(
           strategy.connect(await Misc.impersonate(splitter.address)).withdrawToSplitter(parseUnits('1', 6))
-        ).revertedWith("SB: Wrong amount"); // WRONG_AMOUNT
+        ).revertedWith("SB: Wrong value"); // WRONG_VALUE
       });
     });
 


### PR DESCRIPTION
Add performanceFee and performanceReceiver to StratebyBaseV2
Add setupPerformanceFee (governance only)
Add unit tests for new functions to StrategyBaseV2Tests